### PR TITLE
Tailor .gitignore for RHEL8 make builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Ignore log and object directories
+log/
+obj/
+
+# Ignore executables
+main
+*.out
+
+# Prerequisites
+*.d
+
+# Compiled object files
+*.slo
+*.lo
+*.o
+
+# Precompiled headers
+*.gch
+*.pch
+
+# Compiled dynamic libraries
+*.so
+
+# Compiled static libraries
+*.lai
+*.la
+*.a
+
+# Other
+*.log


### PR DESCRIPTION
## Summary
- remove CMake and Windows-specific ignore patterns
- retain rules for log/, obj/, executables and typical Linux build outputs

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_68a326084dac8329898dba4cced53ff3