### PR TITLE
Update daily log file names to use underscores

### DIFF
--- a/src/tool_logger.cpp
+++ b/src/tool_logger.cpp
@@ -10,7 +10,8 @@ namespace app {
 void LoggerInit(void)
 {
     // ファイル出力(毎日0時にローテート)
-    auto file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>("log/log.log", 0, 0);
+    auto file_sink =
+        std::make_shared<spdlog::sinks::daily_file_format_sink_mt>("log/log_%Y_%m_%d.log", 0, 0);
     // コンソール出力
     auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
 


### PR DESCRIPTION
## Summary
- switch the daily log file sink to the format-based variant so generated files use underscores in their dates

## Testing
- make clean *(fails: find: 'obj/' – No such file or directory)*
- make *(fails: missing boost_filesystem / boost_system libraries in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9675493488329a3e27b2fa01d5dbb