### PR TITLE
Add Japanese comments to tool logger implementation

### DIFF
--- a/src/tool_logger.cpp
+++ b/src/tool_logger.cpp
@@ -18,6 +18,8 @@ namespace app {
 
 namespace {
 
+// 1日の間に生成されるログファイルをサイズ上限で区切りながら出力するカスタムシンク
+// (spdlogのファイルシンクを拡張して、日付ごと・ファイルサイズごとにローテーションする)
 class daily_size_file_sink_mt final : public spdlog::sinks::base_sink<std::mutex> {
 public:
     explicit daily_size_file_sink_mt(std::size_t max_size_bytes)
@@ -26,6 +28,7 @@ public:
             throw spdlog::spdlog_ex("max_size_bytes must be greater than zero");
         }
 
+        // 現在時刻に対応するファイルを開いてロギングを開始する
         open_latest_file_for_day(to_local_tm(spdlog::log_clock::now()));
     }
 
@@ -33,6 +36,7 @@ protected:
     void sink_it_(const spdlog::details::log_msg &msg) override {
         const auto message_tm = to_local_tm(msg.time);
         if (!is_same_day(message_tm, current_tm_)) {
+            // ログの日付が切り替わった場合は新しい日付のファイルへ切り替える
             open_latest_file_for_day(message_tm);
         }
 
@@ -40,15 +44,18 @@ protected:
         base_sink<std::mutex>::formatter_->format(msg, formatted);
 
         if (formatted.size() >= max_size_bytes_) {
+            // 1メッセージでサイズ上限を超える場合は空き容量ができるまでファイルを進める
             while (current_size_ != 0) {
                 rotate_file();
             }
         } else {
+            // 既存ファイルに追記できない場合は十分な空きがあるファイルが見つかるまでローテーション
             while (current_size_ + formatted.size() > max_size_bytes_) {
                 rotate_file();
             }
         }
 
+        // 実際にフォーマット済みメッセージを書き込み、サイズを更新する
         file_helper_.write(formatted);
         current_size_ += formatted.size();
     }
@@ -66,6 +73,7 @@ private:
     }
 
     static spdlog::filename_t make_filename(const std::tm &tm, std::size_t index) {
+        // ファイル名は「log_YYYY_MM_DD._XXlog」という形式で連番を持つ
         std::ostringstream stream;
         stream << "log/log_" << std::put_time(&tm, "%Y_%m_%d") << "._" << std::setfill('0')
                << std::setw(2) << index << "log";
@@ -89,10 +97,12 @@ private:
             last_existing_index = candidate_index;
         }
 
+        // 既存ファイルがあれば最後のものを再利用し、なければインデックス0から開始する
         file_index_ = found_existing ? last_existing_index : 0;
         open_file(make_filename(current_tm_, file_index_));
 
         if (current_size_ >= max_size_bytes_) {
+            // 既存ファイルがすでに上限を超えていれば即座に次のファイルにローテーション
             rotate_file();
         }
     }
@@ -104,12 +114,14 @@ private:
             open_file(filename);
 
             if (current_size_ < max_size_bytes_) {
+                // 書き込み可能なファイルを見つけたらローテーション完了
                 break;
             }
         }
     }
 
     void open_file(const spdlog::filename_t &filename) {
+        // 指定されたファイルを開き、現在のサイズを記録する
         file_helper_.open(filename, false);
         current_size_ = file_helper_.size();
     }
@@ -127,6 +139,7 @@ constexpr std::size_t kMaxLogFileSize = 10 * 1024 * 1024;
 
 void LoggerInit(void)
 {
+    // ファイルへの出力（本クラス）とコンソール出力を組み合わせた複数シンクのロガーを構築
     auto file_sink = std::make_shared<daily_size_file_sink_mt>(kMaxLogFileSize);
     auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
 
@@ -151,6 +164,7 @@ void log_debug_impl(const char *file, int line, const char *fmtstr, ...)
     vsnprintf(buf, sizeof(buf), fmtstr, args);
     va_end(args);
 
+    // 可変長引数から成形したメッセージに、呼び出し元のファイル名と行番号を付加して出力
     std::string newmsg = std::string(buf) + " [" + file + ", " + std::to_string(line) + "]";
     spdlog::debug(newmsg);
 }
@@ -164,6 +178,7 @@ void log_info_impl(const char *file, int line, const char *fmtstr, ...)
     vsnprintf(buf, sizeof(buf), fmtstr, args);
     va_end(args);
 
+    // 共通処理：ログメッセージに呼び出し元情報を追記して出力
     std::string newmsg = std::string(buf) + " [" + file + ", " + std::to_string(line) + "]";
     spdlog::info(newmsg);
 }
@@ -177,6 +192,7 @@ void log_error_impl(const char *file, int line, const char *fmtstr, ...)
     vsnprintf(buf, sizeof(buf), fmtstr, args);
     va_end(args);
 
+    // エラーログも同様に呼び出し元情報付きで出力する
     std::string newmsg = std::string(buf) + " [" + file + ", " + std::to_string(line) + "]";
     spdlog::error(newmsg);
 }


### PR DESCRIPTION
## Summary
- add detailed Japanese comments explaining the custom daily/size file sink
- document the logger initialization flow and message formatting helpers

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68c977b3af3c8329b4f549135c9ad6e5